### PR TITLE
Pass error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-oauth",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Fl0r14n <florian.chis@gmail.com>",
   "homepage": "https://github.com/Fl0r14n/ngx-oauth",
   "description": "A fully OAuth2.1 compliant angular library",

--- a/projects/ngx-oauth/package.json
+++ b/projects/ngx-oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-oauth",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Fl0r14n <florian.chis@gmail.com>",
   "homepage": "https://github.com/Fl0r14n/ngx-oauth",
   "description": "A fully OAuth2.1 compliant angular library",

--- a/projects/ngx-oauth/src/lib/services/oauth.interceptor.ts
+++ b/projects/ngx-oauth/src/lib/services/oauth.interceptor.ts
@@ -28,9 +28,11 @@ export class OAuthInterceptor implements HttpInterceptor {
           if (err.status === 401) {
             this.oauthService.token = null;
             this.oauthService.status = OAuthStatus.DENIED;
-            return EMPTY;
+            if (!this.isPathExcepted(req)) {
+              return EMPTY;
+            }
           }
-          return throwError(() => new Error(err));
+          return throwError(err);
         })
       );
     } else {

--- a/projects/ngx-oauth/src/lib/services/oauth.service.ts
+++ b/projects/ngx-oauth/src/lib/services/oauth.service.ts
@@ -297,8 +297,8 @@ export class OAuthService {
         ...scope ? {scope} : {},
       }
     }), {headers: REQUEST_HEADER}).pipe(
-      catchError(() => {
-        this.token = null;
+      catchError((err) => {
+        this.token = err;
         this.status = OAuthStatus.DENIED;
         return EMPTY;
       })


### PR DESCRIPTION
motive: Interceptor prevents all error response body's to get to the client in case of 401 -> but client might need that body for certain scenarios: ex BE login error localisation based on diverse criteria

This PR 
- throws error as is further  from the interceptor in case of ignored paths request
- saves the error response on token in case of credential login (latest is implemented for the other login types already)

If this pr does not match your expectation of workflow for the library please let me know